### PR TITLE
Improve app startup message to show clickable URL

### DIFF
--- a/priv/templates/arizona.hello_world/src/app.erl
+++ b/priv/templates/arizona.hello_world/src/app.erl
@@ -12,6 +12,7 @@ start(_StartType, _StartArgs) ->
     maybe
         {ok, SupPid} ?= {{name}}_sup:start_link(),
         ok ?= arizona:start({{name}}_conf:arizona()),
+        ok = io:format("Arizona app started at http://localhost:1912~n"),
         {ok, SupPid}
     else
         {error, Reason} ->

--- a/priv/templates/arizona.presence/src/app.erl
+++ b/priv/templates/arizona.presence/src/app.erl
@@ -13,6 +13,7 @@ start(_StartType, _StartArgs) ->
         {ok, SupPid} ?= {{name}}_sup:start_link(),
         CounterRef = counters:new(1, [write_concurrency]),
         ok ?= arizona:start({{name}}_conf:arizona(CounterRef)),
+        ok = io:format("Arizona app started at http://localhost:1912~n"),
         {ok, SupPid}
     else
         {error, Reason} ->


### PR DESCRIPTION
Change 'Arizona app started in port 1912' to 'Arizona app started at http://localhost:1912' so users can click the link or easily copy/paste the URL to access their app.