### PR TITLE
Fix hello world template configuration function

### DIFF
--- a/priv/templates/arizona.hello_world/src/conf.erl
+++ b/priv/templates/arizona.hello_world/src/conf.erl
@@ -1,11 +1,10 @@
 -module({{name}}_conf).
 
--export([arizona/1]).
+-export([arizona/0]).
 
--spec arizona(CounterRef) -> Config when
-    CounterRef :: counters:counters_ref(),
+-spec arizona() -> Config when
     Config :: arizona:config().
-arizona(CounterRef) ->
+arizona() ->
     #{
         server => #{
             transport_opts => [{port, 8080}],


### PR DESCRIPTION
Remove unnecessary CounterRef parameter from arizona/1 function in hello world template since counters are only needed for the presence template.