### PR TITLE
Remove hardcoded port from hello world template configuration

### DIFF
--- a/priv/templates/arizona.hello_world/src/conf.erl
+++ b/priv/templates/arizona.hello_world/src/conf.erl
@@ -7,7 +7,6 @@
 arizona() ->
     #{
         server => #{
-            transport_opts => [{port, 8080}],
             routes => routes()
         },
         reloader => #{


### PR DESCRIPTION
Remove transport_opts with port 8080 to let Arizona framework use its default port configuration, ensuring consistency with the startup message.