### PR TITLE
Fix Tailwind CSS recompilation for Erlang template files

### DIFF
--- a/priv/templates/arizona.frontend/config/sys.config
+++ b/priv/templates/arizona.frontend/config/sys.config
@@ -19,8 +19,8 @@
                 #{
                     handler => {{{name}}_css_reloader, #{}},
                     watcher => #{
-                        directories => ["assets/css"],
-                        patterns => [".*\\.css$"]
+                        directories => ["assets/css", "src"],
+                        patterns => [".*\\.css$", ".*\\.erl$"]
                     }
                 }
             ]


### PR DESCRIPTION
- Add "src" directory to CSS reloader watcher directories
- Ensures Tailwind recompiles when CSS classes change in .erl template files
- Resolves issue where class changes in view templates weren't triggering rebuilds
- Maintains existing CSS file watching for assets/css directory