### PR TITLE
Add JavaScript hot-reloading to frontend template

### DIFF
--- a/priv/templates/arizona.frontend/config/sys.config
+++ b/priv/templates/arizona.frontend/config/sys.config
@@ -22,6 +22,13 @@
                         directories => ["assets/css", "src"],
                         patterns => [".*\\.css$", ".*\\.erl$"]
                     }
+                },
+                #{
+                    handler => {{{name}}_js_reloader, #{}},
+                    watcher => #{
+                        directories => ["assets/js"],
+                        patterns => [".*\\.js$"]
+                    }
                 }
             ]
         }},

--- a/priv/templates/arizona.frontend/src/js_reloader.erl
+++ b/priv/templates/arizona.frontend/src/js_reloader.erl
@@ -1,0 +1,13 @@
+-module({{name}}_js_reloader).
+-behaviour(arizona_reloader).
+-export([reload/2]).
+
+reload(_Files, _Opts) ->
+    try
+        CompileResult = os:cmd("npm run build:js", #{exception_on_failure => true}),
+        ok = io:format("~ts", [CompileResult]),
+        arizona_pubsub:broadcast(~"reload", js)
+    catch
+        error:{command_failed, ResultBeforeFailure, _ExitCode} ->
+            io:format("JS build failed:~n~ts~n", [ResultBeforeFailure])
+    end.


### PR DESCRIPTION
- Add js_reloader.erl module to handle JavaScript rebuilds
- Configure reloader to watch assets/js directory for .js file changes
- Runs npm run build:js when JavaScript files are modified
- Broadcasts js reload event via arizona_pubsub for live updates
- Includes error handling for failed JS builds with output logging