### PR TITLE
Revert to OTP 28+ minimum requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,7 @@ $ rebar3 ci
 
 ## Requirements
 
-- **Erlang/OTP 27+** - For template generation (`rebar3 new arizona.*`)
-- **Erlang/OTP 28+** - Required for interactive CLI (`rebar3 arizona`)
+- Erlang/OTP 28+
 
 ## License
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "27"}.
+{minimum_otp_vsn, "28"}.
 
 {erl_opts, [
     debug_info,


### PR DESCRIPTION
- Arizona framework uses nominal types from OTP 28
- Both template generation and interactive CLI require OTP 28+
- Nominal types cannot be conditionally compiled on older OTP versions
- Update rebar.config minimum_otp_vsn back to "28"
- Simplify README requirements documentation